### PR TITLE
Extends passed table on `newSystem` and `sortedSystem`.

### DIFF
--- a/ecs.lua
+++ b/ecs.lua
@@ -3,7 +3,8 @@ local ecs = {}
 -- Local versions of standard lua functions
 local tinsert = table.insert
 local tremove = table.remove
-
+local tsort = table.sort
+local setmetabale = setmetatable
 
 -- Systems
 
@@ -41,7 +42,7 @@ local function sortedSystemOnModify(system)
 		end
 		system.sortDelegate = sortDelegate
 	end
-	table.sort(entities, sortDelegate)
+	tsort(entities, sortDelegate)
 	for i = 1, #entities do
 		indices[entities[i]] = i
 	end
@@ -54,14 +55,14 @@ end
 --
 -- Systems have their own `update` method, so don't implement a a custom `update` callback for Systems.
 function ecs.newSystem(table)
-	table = table or {}
+	table = table and setmetatable({}, { __index = table }) or {}
 	table.update = processingSystemUpdate
 	return table
 end
 
 --- Creates a new Sorted System. Sorted Systems sort their Entities according to a user-defined method, `system:compare(e1, e2)`, which should return true if `e1` should come before `e2` and false otherwise.
 function ecs.sortedSystem(table)
-	table = table or {}
+	table = table and setmetatable({}, { __index = table }) or {}
 	table.update = processingSystemUpdate
 	table.onModify = sortedSystemOnModify
 	return table


### PR DESCRIPTION
Prevent passed table from directly modified. This is inspired by kitito's stateful.lua library.

The passed table works as base table (using metatable `__index`). This prevent accident when system table get modified during process and left after effects on next another world with same system, just to be sure.